### PR TITLE
chore: upgrade @hapi/lab version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@hapi/code": "^8.0.1",
-    "@hapi/lab": "^22.0.4",
+    "@hapi/lab": "^24.0.0",
     "@types/hapi": "^18.0.3",
     "@types/node": "^12.12.31",
     "lab-transform-typescript": "^3.0.1",


### PR DESCRIPTION
Fix #5 
Upgrade the @hapi/lab version to 24.0.0.
I guess the old version didn't support Node.js 15.0.1.

![image](https://user-images.githubusercontent.com/22230889/97121724-5fb39700-175b-11eb-98fe-86f03c194c0e.png)
